### PR TITLE
Add Dockerfile and instructions to run Win95 as a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ LABEL maintainer "Paul DeCarlo <toolboc@gmail.com>"
 
 RUN apt update && apt install -y \
     libgtk-3-0 \
+    libcanberra-gtk3-module \
     libx11-xcb-dev \
     libgconf2-dev \
     libnss3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM node:10.9-stretch
 
 LABEL maintainer "Paul DeCarlo <toolboc@gmail.com>"
 
-RUN apt-get update && apt-get install -y \
+RUN apt update && apt install -y \
     libgtk-3-0 \
     libx11-xcb-dev \
     libgconf2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# DESCRIPTION:	  Run Windows 95 in a container
+# AUTHOR:		  Paul DeCarlo <toolboc@gmail.com>
+#
+#   Made possible through prior art by:
+#   copy (v86 - x86 virtualization in JavaScript) 
+#   felixrieseberg (Windows95 running in electron) 
+#   Microsoft (Windows 95)
+#
+#   ***Docker Run Command***
+#
+#   docker run -it \
+#    -v /tmp/.X11-unix:/tmp/.X11-unix \ # mount the X11 socket
+#    -e DISPLAY=unix$DISPLAY \ # pass the display
+#    --device /dev/snd \ # sound
+#    --name windows95 \
+#    toolboc/windows95
+#
+#   ***TroubleShooting***
+#   If you receive Gtk-WARNING **: cannot open display: unix:0
+#   Run:
+#       xhost +
+#
+
+FROM node:10.9-stretch
+
+LABEL maintainer "Paul DeCarlo <toolboc@gmail.com>"
+
+RUN apt-get update && apt-get install -y \
+    libgtk-3-0 \
+    libx11-xcb-dev \
+    libgconf2-dev \
+    libnss3 \
+    libasound2 \
+    libxtst-dev \
+    libxss1 \
+    git \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+RUN npm install 
+
+ENTRYPOINT [ "npm", "start"]

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ You'll likely be better off with an actual virtualization app, but the short ans
 640x480 @ 256 colors before starting DOS games - just like in the good ol' days.
 
 ## Can it run in a container?
-Of course!  Currently this is only supported on Linux, simply install [Docker](http://docker.io) on your distro of choice and run the following:
-
-    docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY --device /dev/snd --name windows95 toolboc/windows95
-
-Note: You may need to run `xhost +` on your system to allow connections to the X server running on the host.
+[Of course!](./docs/docker-instructions.md)  
 
 ## How's the code?
 This only works well by accident and was mostly a joke. The code quality is accordingly.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ You'll likely be better off with an actual virtualization app, but the short ans
 @DisplacedGamers](https://youtu.be/xDXqmdFxofM) I can recommend that you switch to a resolution of 
 640x480 @ 256 colors before starting DOS games - just like in the good ol' days.
 
+## Can it run in a container?
+Of course!  Currently this is only supported on Linux, simply install [Docker](http://docker.io) on your distro of choice and run the following:
+
+    docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY --device /dev/snd --name windows95 toolboc/windows95
+
 ## How's the code?
 This only works well by accident and was mostly a joke. The code quality is accordingly.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Of course!  Currently this is only supported on Linux, simply install [Docker](h
 
     docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY --device /dev/snd --name windows95 toolboc/windows95
 
+Note: You may need to run `xhost +` on your system to allow connections to the X server running on the host.
+
 ## How's the code?
 This only works well by accident and was mostly a joke. The code quality is accordingly.
 

--- a/docs/docker-instructions.md
+++ b/docs/docker-instructions.md
@@ -1,0 +1,25 @@
+# Running Windows 95 in Docker
+
+## Display using a volume mount of the host X11 Unix Socket (Linux Only):
+
+**Requirements:**
+* Linux OS with a running X-Server Display
+* [Docker](http://docker.io) 
+
+        docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY --device /dev/snd --name windows95 toolboc/windows95
+
+
+Note: You may need to run `xhost +` on your system to allow connections to the X server running on the host.
+
+## Display using Xming X11 Server over tcp Socket (Windows and beyond):
+
+**Requirements:**
+* [Xming](https://sourceforge.net/projects/xming/)
+* [Docker](http://docker.io) 
+
+1. Start the Xming X11 Server
+2. Obtain the ip of the host machine running the Xming server
+3. Edit X0.hosts (Located in the install directory of Xming) by adding the ip of the host machine obtained in step 2
+4. Run the command below and replace the `<XmingServerHostIp>` placeholder with the ip from step 2
+
+        docker run -it -e DISPLAY=<XmingServerHostIp> --name windows95 toolboc/windows95


### PR DESCRIPTION
* Added Dockerfile

Confirmed working as-is with Linux, can work elsewhere with X-11 forwarding.  
Docker image currently hosted @ https://hub.docker.com/r/toolboc/windows95/