### PR TITLE
Add an online live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Yes! Quite well, actually - on macOS, Windows, and Linux. Bear in mind that this
 ## Should this have been a native app?
 Absolutely.
 
+## Can it run in the cloud too?
+Sure, you can also run Windows 95 in Electron, in a virtual X server, in a JavaScript VNC client, in a Kubernetes workspace. What could go wrong?
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/felixrieseberg/windows95)
+
 ## Does it run Doom (or my other favorite game)?
 You'll likely be better off with an actual virtualization app, but the short answer is yes. [Thanks to
 @DisplacedGamers](https://youtu.be/xDXqmdFxofM) I can recommend that you switch to a resolution of


### PR DESCRIPTION
Hello! Thank you so much for doing this, it's a bit magical.

I work on Gitpod.io, a service that provides free online workspaces, and I just [had](https://twitter.com/gitpodio/status/1095689108578537472) to make Windows 95 run in there. And I think it makes a cool online demo for this project:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/felixrieseberg/windows95)
<img width="1552" alt="screenshot 2019-02-13 at 15 12 25" src="https://user-images.githubusercontent.com/599268/52723577-1387e980-2fae-11e9-88af-838c15caddbd.png">
Please let me know what you think. 🙂 