### PR TITLE
fix docker mac doc

### DIFF
--- a/docs/docker-instructions.md
+++ b/docs/docker-instructions.md
@@ -35,5 +35,5 @@ xhost +
 ```
 4. run 
 ```
-docker run -it -e DISPLAY=host.docker.internal:1 toolboc/windows95
+docker run -it -e DISPLAY=host.docker.internal:0 toolboc/windows95
 ```


### PR DESCRIPTION

Environment:
- Macos Monterey 12.6.3
- 2.6 Ghz-6-Core Intel i7

When running  `docker run -it -e DISPLAY=host.docker.internal:1 toolboc/windows95`

 i get this error


```
(electron:82): Gtk-WARNING **: cannot open display: host.docker.internal:1
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! windows95@1.1.0 start: `electron-forge start`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the windows95@1.1.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2023-02-11T22_10_29_483Z-debug.log
```

By setting `host.docker.internal:0` instead,  runs nicely