### PR TITLE
Bump electron version to latest version to patch security vulnerability 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^12.19.9",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "electron": "25.3.0",
+    "electron": "^28.3.0",
     "less": "^3.13.0",
     "node-abi": "^3.45.0",
     "parcel-bundler": "^1.12.5",


### PR DESCRIPTION
This version `electron` is vulnerable to `Out-of-Bounds memory access` in `V8` component. This vulnerability allowed a remote attacker to perform arbitrary read/write via a crafted HTML page.

I have bumped your electron version to remove this vulnerability.

## Sources
[Chrome releases](https://chromereleases.googleblog.com/2024/04/stable-channel-update-for-desktop.html)
[Synk](https://security.snyk.io/vuln/SNYK-JS-ELECTRON-6564965)