### PR TITLE
Stabilize VM info bar width, add sparklines and Interface settings

### DIFF
--- a/src/less/status.less
+++ b/src/less/status.less
@@ -27,10 +27,6 @@
   transition: transform 0.12s ease-out;
   font-family: SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
-  .lz {
-    opacity: 0.3;
-  }
-
   a.toggle {
     display: inline-block;
     width: 4ch;

--- a/src/less/status.less
+++ b/src/less/status.less
@@ -25,6 +25,28 @@
   max-height: 18px;
   top: 0;
   transition: transform 0.12s ease-out;
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+  .lz {
+    opacity: 0.3;
+  }
+
+  a.toggle {
+    display: inline-block;
+    width: 4ch;
+    text-align: center;
+  }
+
+  .spark {
+    vertical-align: -2px;
+    margin-right: 4px;
+
+    polyline {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: 1;
+    }
+  }
 
   &.hidden {
     transform: translateX(-50%) translateY(-100%);

--- a/src/renderer/card-settings.tsx
+++ b/src/renderer/card-settings.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { resetState } from "./utils/reset-state";
+import { InfoBarSettings } from "./info-bar-settings";
 
 // v86's IDE CD-ROM path is currently broken; flip this once it works again.
 const CDROM_ENABLED = false;
@@ -15,9 +16,11 @@ interface CardSettingsProps {
   floppy?: File;
   cdrom?: File;
   smbSharePath: string;
+  infoBarSettings: InfoBarSettings;
+  setInfoBarSettings: (s: InfoBarSettings) => void;
 }
 
-type Tab = "floppy" | "cdrom" | "network" | "state";
+type Tab = "floppy" | "cdrom" | "network" | "interface" | "state";
 
 interface CardSettingsState {
   tab: Tab;
@@ -61,6 +64,7 @@ export class CardSettings extends React.Component<
             {this.renderTab("floppy", "Floppy Drive")}
             {CDROM_ENABLED && this.renderTab("cdrom", "CD-ROM")}
             {this.renderTab("network", "Network Share")}
+            {this.renderTab("interface", "Interface")}
             {this.renderTab("state", "Machine State")}
           </menu>
           <div className="window settings-panel" role="tabpanel">
@@ -68,6 +72,7 @@ export class CardSettings extends React.Component<
               {tab === "floppy" && this.renderFloppy()}
               {tab === "cdrom" && this.renderCdrom()}
               {tab === "network" && this.renderSmbShare()}
+              {tab === "interface" && this.renderInterface()}
               {tab === "state" && this.renderState()}
             </div>
           </div>
@@ -210,6 +215,42 @@ export class CardSettings extends React.Component<
             Choose folder...
           </button>
         </div>
+      </fieldset>
+    );
+  }
+
+  private renderInterface() {
+    const { infoBarSettings, setInfoBarSettings } = this.props;
+
+    const checkbox = (key: keyof InfoBarSettings, label: string) => (
+      <div className="field-row">
+        <input
+          id={`ibs-${key}`}
+          type="checkbox"
+          checked={infoBarSettings[key]}
+          onChange={(e) =>
+            setInfoBarSettings({ ...infoBarSettings, [key]: e.target.checked })
+          }
+        />
+        <label htmlFor={`ibs-${key}`}>{label}</label>
+      </div>
+    );
+
+    return (
+      <fieldset>
+        <legend>Info bar</legend>
+        <div className="settings-row">
+          <img className="settings-icon" src="../../static/settings.png" />
+          <p>
+            The bar at the top of the emulator shows live machine stats. Choose
+            which metrics to display and whether to draw sparkline graphs next
+            to them.
+          </p>
+        </div>
+        {checkbox("showCpu", "Show CPU speed")}
+        {checkbox("showDisk", "Show disk throughput")}
+        {checkbox("showNet", "Show network throughput")}
+        {checkbox("showSparklines", "Show sparklines")}
       </fieldset>
     );
   }

--- a/src/renderer/emulator-info.tsx
+++ b/src/renderer/emulator-info.tsx
@@ -1,9 +1,11 @@
 import * as React from "react";
+import { InfoBarSettings } from "./info-bar-settings";
 
 interface EmulatorInfoProps {
   toggleInfo: () => void;
   emulator: any;
   hidden: boolean;
+  settings: InfoBarSettings;
 }
 
 interface EmulatorInfoState {
@@ -14,7 +16,6 @@ interface EmulatorInfoState {
   netTx: number;
   lastCounter: number;
   lastTick: number;
-  full: boolean;
   history: {
     cpu: number[];
     diskRead: number[];
@@ -68,7 +69,6 @@ export class EmulatorInfo extends React.Component<
       netTx: 0,
       lastCounter: 0,
       lastTick: 0,
-      full: false,
       history: {
         cpu: new Array(HISTORY_LEN).fill(0),
         diskRead: new Array(HISTORY_LEN).fill(0),
@@ -80,27 +80,36 @@ export class EmulatorInfo extends React.Component<
   }
 
   public render() {
-    const { cpu, diskRead, diskWrite, netRx, netTx, full, history } = this.state;
-    const { hidden, toggleInfo } = this.props;
+    const { cpu, diskRead, diskWrite, netRx, netTx, history } = this.state;
+    const { hidden, toggleInfo, settings } = this.props;
+    const { showCpu, showDisk, showNet, showSparklines: spark } = settings;
 
     return (
       <>
         <div id="status-hotzone" />
         <div id="status" className={hidden ? "hidden" : ""}>
-          CPU: {full && <Sparkline data={history.cpu} />}
-          {this.pad(Math.min(cpu, 999), 3)}M/s | Disk:{" "}
-          {full && <Sparkline data={history.diskRead} />}R {this.rate(diskRead)}{" "}
-          {full && <Sparkline data={history.diskWrite} />}W {this.rate(diskWrite)}{" "}
-          | Net: {full && <Sparkline data={history.netRx} />}↓{this.rate(netRx)}{" "}
-          {full && <Sparkline data={history.netTx} />}↑{this.rate(netTx)} |{" "}
-          <a
-            href="#"
-            className="toggle"
-            onClick={() => this.setState({ full: !full })}
-          >
-            {full ? "Mini" : "Full"}
-          </a>{" "}
-          |{" "}
+          {showCpu && (
+            <>
+              CPU: {spark && <Sparkline data={history.cpu} />}
+              {this.fmt(cpu, ["M", "G"])}/s |{" "}
+            </>
+          )}
+          {showDisk && (
+            <>
+              Disk: {spark && <Sparkline data={history.diskRead} />}R{" "}
+              {this.fmt(diskRead, ["B", "K", "M", "G"])}/s{" "}
+              {spark && <Sparkline data={history.diskWrite} />}W{" "}
+              {this.fmt(diskWrite, ["B", "K", "M", "G"])}/s |{" "}
+            </>
+          )}
+          {showNet && (
+            <>
+              Net: {spark && <Sparkline data={history.netRx} />}↓
+              {this.fmt(netRx, ["B", "K", "M", "G"])}/s{" "}
+              {spark && <Sparkline data={history.netTx} />}↑
+              {this.fmt(netTx, ["B", "K", "M", "G"])}/s |{" "}
+            </>
+          )}
           <a href="#" className="toggle" onClick={toggleInfo}>
             {hidden ? "Pin" : "Hide"}
           </a>
@@ -195,33 +204,19 @@ export class EmulatorInfo extends React.Component<
   }
 
   /**
-   * Format bytes/sec into a compact human string.
+   * Format a value as "N.NU" by walking the unit ladder until it fits in
+   * one digit before the decimal. Always exactly 4 chars (e.g. "0.0B",
+   * "3.2K", "9.9G") so the bar width never changes.
    */
-  private pad(n: number, width: number) {
-    const s = String(n);
-    const zeros = Math.max(0, width - s.length);
-    return (
-      <>
-        {zeros > 0 && <span className="lz">{"0".repeat(zeros)}</span>}
-        {s}
-      </>
-    );
-  }
-
-  private rate(bytesPerSec: number) {
-    const units = ["B", "K", "M", "G"];
-    let v = Math.max(0, bytesPerSec);
+  private fmt(value: number, units: string[]) {
+    let v = Math.max(0, value);
     let u = 0;
-    while (v >= 100 && u < units.length - 1) {
-      v /= 1024;
+    while (v >= 10 && u < units.length - 1) {
+      v /= 1000;
       u++;
     }
-    return (
-      <>
-        {this.pad(Math.min(99, Math.round(v)), 2)}
-        {units[u]}/s
-      </>
-    );
+    if (v >= 9.95) v = 9.9;
+    return `${v.toFixed(1)}${units[u]}`;
   }
 
   /**

--- a/src/renderer/emulator-info.tsx
+++ b/src/renderer/emulator-info.tsx
@@ -14,6 +14,31 @@ interface EmulatorInfoState {
   netTx: number;
   lastCounter: number;
   lastTick: number;
+  full: boolean;
+  history: {
+    cpu: number[];
+    diskRead: number[];
+    diskWrite: number[];
+    netRx: number[];
+    netTx: number[];
+  };
+}
+
+const HISTORY_LEN = 30;
+
+function Sparkline({ data }: { data: number[] }) {
+  const w = 20;
+  const h = 12;
+  const max = Math.max(1, ...data);
+  const step = data.length > 1 ? w / (data.length - 1) : 0;
+  const points = data
+    .map((v, i) => `${i * step},${h - (v / max) * h}`)
+    .join(" ");
+  return (
+    <svg className="spark" width={w} height={h} viewBox={`0 0 ${w} ${h}`}>
+      <polyline points={points} />
+    </svg>
+  );
 }
 
 export class EmulatorInfo extends React.Component<
@@ -43,22 +68,40 @@ export class EmulatorInfo extends React.Component<
       netTx: 0,
       lastCounter: 0,
       lastTick: 0,
+      full: false,
+      history: {
+        cpu: new Array(HISTORY_LEN).fill(0),
+        diskRead: new Array(HISTORY_LEN).fill(0),
+        diskWrite: new Array(HISTORY_LEN).fill(0),
+        netRx: new Array(HISTORY_LEN).fill(0),
+        netTx: new Array(HISTORY_LEN).fill(0),
+      },
     };
   }
 
   public render() {
-    const { cpu, diskRead, diskWrite, netRx, netTx } = this.state;
+    const { cpu, diskRead, diskWrite, netRx, netTx, full, history } = this.state;
     const { hidden, toggleInfo } = this.props;
 
     return (
       <>
         <div id="status-hotzone" />
         <div id="status" className={hidden ? "hidden" : ""}>
-          CPU: <span>{cpu}M/s</span> | Disk:{" "}
-          <span>R {this.rate(diskRead)}</span>{" "}
-          <span>W {this.rate(diskWrite)}</span> | Net:{" "}
-          <span>↓{this.rate(netRx)}</span> <span>↑{this.rate(netTx)}</span> |{" "}
-          <a href="#" onClick={toggleInfo}>
+          CPU: {full && <Sparkline data={history.cpu} />}
+          {this.pad(Math.min(cpu, 999), 3)}M/s | Disk:{" "}
+          {full && <Sparkline data={history.diskRead} />}R {this.rate(diskRead)}{" "}
+          {full && <Sparkline data={history.diskWrite} />}W {this.rate(diskWrite)}{" "}
+          | Net: {full && <Sparkline data={history.netRx} />}↓{this.rate(netRx)}{" "}
+          {full && <Sparkline data={history.netTx} />}↑{this.rate(netTx)} |{" "}
+          <a
+            href="#"
+            className="toggle"
+            onClick={() => this.setState({ full: !full })}
+          >
+            {full ? "Mini" : "Full"}
+          </a>{" "}
+          |{" "}
+          <a href="#" className="toggle" onClick={toggleInfo}>
             {hidden ? "Pin" : "Hide"}
           </a>
         </div>
@@ -154,11 +197,31 @@ export class EmulatorInfo extends React.Component<
   /**
    * Format bytes/sec into a compact human string.
    */
+  private pad(n: number, width: number) {
+    const s = String(n);
+    const zeros = Math.max(0, width - s.length);
+    return (
+      <>
+        {zeros > 0 && <span className="lz">{"0".repeat(zeros)}</span>}
+        {s}
+      </>
+    );
+  }
+
   private rate(bytesPerSec: number) {
-    if (bytesPerSec <= 0) return "0";
-    if (bytesPerSec < 1024) return `${bytesPerSec}B/s`;
-    if (bytesPerSec < 1024 * 1024) return `${Math.round(bytesPerSec / 1024)}K/s`;
-    return `${(bytesPerSec / 1024 / 1024).toFixed(1)}M/s`;
+    const units = ["B", "K", "M", "G"];
+    let v = Math.max(0, bytesPerSec);
+    let u = 0;
+    while (v >= 100 && u < units.length - 1) {
+      v /= 1024;
+      u++;
+    }
+    return (
+      <>
+        {this.pad(Math.min(99, Math.round(v)), 2)}
+        {units[u]}/s
+      </>
+    );
   }
 
   /**
@@ -173,15 +236,31 @@ export class EmulatorInfo extends React.Component<
     const deltaTime = now - lastTick;
     const deltaSec = deltaTime / 1000;
 
-    this.setState({
+    const cpu = Math.round(ips / deltaTime / 1000);
+    const diskRead = Math.round(this.diskReadBytes / deltaSec);
+    const diskWrite = Math.round(this.diskWriteBytes / deltaSec);
+    const netRx = Math.round(this.netRxBytes / deltaSec);
+    const netTx = Math.round(this.netTxBytes / deltaSec);
+
+    const push = (arr: number[], v: number) =>
+      [...arr, v].slice(-HISTORY_LEN);
+
+    this.setState((s) => ({
       lastTick: now,
       lastCounter: instructionCounter,
-      cpu: Math.round(ips / deltaTime / 1000),
-      diskRead: Math.round(this.diskReadBytes / deltaSec),
-      diskWrite: Math.round(this.diskWriteBytes / deltaSec),
-      netRx: Math.round(this.netRxBytes / deltaSec),
-      netTx: Math.round(this.netTxBytes / deltaSec),
-    });
+      cpu,
+      diskRead,
+      diskWrite,
+      netRx,
+      netTx,
+      history: {
+        cpu: push(s.history.cpu, cpu),
+        diskRead: push(s.history.diskRead, diskRead),
+        diskWrite: push(s.history.diskWrite, diskWrite),
+        netRx: push(s.history.netRx, netRx),
+        netTx: push(s.history.netTx, netTx),
+      },
+    }));
 
     this.diskReadBytes = 0;
     this.diskWriteBytes = 0;

--- a/src/renderer/emulator.tsx
+++ b/src/renderer/emulator.tsx
@@ -8,6 +8,11 @@ import { getDiskImageSize } from "../utils/disk-image-size";
 import { CardStart } from "./card-start";
 import { CardSettings } from "./card-settings";
 import { EmulatorInfo } from "./emulator-info";
+import {
+  InfoBarSettings,
+  loadInfoBarSettings,
+  saveInfoBarSettings,
+} from "./info-bar-settings";
 import { getStatePath } from "./utils/get-state-path";
 import { Win95Window } from "./app";
 import { resetState } from "./utils/reset-state";
@@ -33,6 +38,7 @@ export interface EmulatorState {
   isCursorCaptured: boolean;
   isInfoDisplayed: boolean;
   isRunning: boolean;
+  infoBarSettings: InfoBarSettings;
 }
 
 export class Emulator extends React.Component<{}, EmulatorState> {
@@ -55,6 +61,7 @@ export class Emulator extends React.Component<{}, EmulatorState> {
       currentUiCard: "start",
       isInfoDisplayed: true,
       smbSharePath: "",
+      infoBarSettings: loadInfoBarSettings(),
       // We can start pretty large
       // If it's too large, it'll just grow until it hits borders
       scale: 2,
@@ -235,6 +242,11 @@ export class Emulator extends React.Component<{}, EmulatorState> {
           floppy={floppyFile}
           cdrom={cdromFile}
           smbSharePath={this.state.smbSharePath}
+          infoBarSettings={this.state.infoBarSettings}
+          setInfoBarSettings={(infoBarSettings) => {
+            this.setState({ infoBarSettings });
+            saveInfoBarSettings(infoBarSettings);
+          }}
           navigate={navigate}
         />
       );
@@ -270,6 +282,7 @@ export class Emulator extends React.Component<{}, EmulatorState> {
     return (
       <EmulatorInfo
         emulator={this.state.emulator}
+        settings={this.state.infoBarSettings}
         hidden={!this.state.isInfoDisplayed}
         toggleInfo={() => {
           this.setState({ isInfoDisplayed: !this.state.isInfoDisplayed });

--- a/src/renderer/info-bar-settings.ts
+++ b/src/renderer/info-bar-settings.ts
@@ -1,0 +1,29 @@
+export interface InfoBarSettings {
+  showCpu: boolean;
+  showDisk: boolean;
+  showNet: boolean;
+  showSparklines: boolean;
+}
+
+export const DEFAULT_INFO_BAR_SETTINGS: InfoBarSettings = {
+  showCpu: true,
+  showDisk: true,
+  showNet: true,
+  showSparklines: true,
+};
+
+const KEY = "infoBarSettings";
+
+export function loadInfoBarSettings(): InfoBarSettings {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (raw) return { ...DEFAULT_INFO_BAR_SETTINGS, ...JSON.parse(raw) };
+  } catch {}
+  return { ...DEFAULT_INFO_BAR_SETTINGS };
+}
+
+export function saveInfoBarSettings(s: InfoBarSettings) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(s));
+  } catch {}
+}


### PR DESCRIPTION
## What

Makes the VM info bar at the top of the emulator hold a fixed width regardless of the values it shows, and lets users configure what it displays.

- **Fixed-width numbers**: every metric renders as `N.NU/s` (e.g. `0.0B/s`, `3.2K/s`, `0.2G/s`). The unit auto-scales by 1000× so the numeric part is always one digit + one decimal. Bar uses a monospace font so unit letters don't jitter either.
- **Sparklines**: 20×12px inline SVG line graphs next to each metric, showing the last ~15s of history. On by default.
- **Interface settings tab**: new tab in the pre-boot Properties dialog with checkboxes for *Show CPU / Disk / Net / Sparklines*. Persisted to `localStorage`.
- Hide/Pin link is now a fixed-width 4ch block so toggling it doesn't shift the bar.

## Why

The bar is centered via `translateX(-50%)`, so any change in text width made it visibly jump every 500ms as throughput numbers went from 1 to 3+ digits.

## Notes

- The `N.N` scheme trades precision for stability: values in the 10-49 range of any unit display as `0.0` of the next unit. Fine for a glanceable status indicator.
- `info-bar-settings.ts` is a small localStorage wrapper; defaults are all-on so existing users see everything including sparklines.