### PR TITLE
Show git branch in window title during development

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -1,6 +1,27 @@
 import { BrowserWindow, shell } from "electron";
+import { execFileSync } from "child_process";
+
+import { isDevMode } from "../utils/devmode";
 
 let mainWindow: BrowserWindow | null = null;
+
+function getDevBranchSuffix(): string {
+  if (!isDevMode()) return "";
+
+  try {
+    const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+
+    if (branch && branch !== "master" && branch !== "main") {
+      return ` (${branch})`;
+    }
+  } catch {
+    // git not available or not a repo — ignore
+  }
+
+  return "";
+}
 
 export function getOrCreateWindow(): BrowserWindow {
   if (mainWindow) return mainWindow;
@@ -17,6 +38,14 @@ export function getOrCreateWindow(): BrowserWindow {
       contextIsolation: false,
     },
   });
+
+  const branchSuffix = getDevBranchSuffix();
+  if (branchSuffix) {
+    mainWindow.on("page-title-updated", (event, title) => {
+      event.preventDefault();
+      mainWindow?.setTitle(`${title}${branchSuffix}`);
+    });
+  }
 
   mainWindow.loadFile("./dist/static/index.html");
 


### PR DESCRIPTION
When running via `yarn start` on a branch other than `master`/`main`, the window title now includes the current branch name — e.g. `windows95 (my-feature)` — making it easy to tell dev windows apart.

- Gated on `isDevMode()` (i.e. `process.defaultApp`), so packaged builds never shell out to git.
- Uses `execFileSync` (no shell) and swallows errors if git is unavailable.
- Hooks `page-title-updated` so the suffix survives the renderer setting `document.title`.

Verified locally: title rendered as `windows95 (claude/epic-heyrovsky)`.