### PR TITLE
Raw TCP relay for guest egress beyond port 80

### DIFF
--- a/src/renderer/debug-harness.ts
+++ b/src/renderer/debug-harness.ts
@@ -76,7 +76,11 @@ export function startProbe(emulator: any) {
 
   // WIN95_PROBE_SCRIPT=\\HOST  → after desktop, send Win+R, type, Enter
   const scriptCmd = process.env.WIN95_PROBE_SCRIPT;
-  let scriptArmed = !!scriptCmd;
+  // WIN95_PROBE_RUN='telnet 1.2.3.4 7777' → literal text into Start→Run,
+  // Enter, then optional WIN95_PROBE_RUN_AFTER keystrokes after _RUN_WAIT ms.
+  const runCmd = process.env.WIN95_PROBE_RUN;
+  const runAfter = process.env.WIN95_PROBE_RUN_AFTER;
+  let scriptArmed = !!scriptCmd || !!runCmd;
 
   const tick = () => {
     try {
@@ -99,6 +103,32 @@ export function startProbe(emulator: any) {
       // we send Esc first to clear it.
       if (scriptArmed && s.phase === "desktop" && s.uptimeSec > 8) {
         scriptArmed = false;
+        if (runCmd) {
+          console.log("[probe] desktop detected, Run →", runCmd);
+          runScript(emulator, [
+            { type: "wait", ms: 3000 },
+            { type: "keys", dn: SC.ESC_DN, up: SC.ESC_UP },
+            { type: "wait", ms: 1000 },
+            { type: "keys", dn: SC.ESC_DN, up: SC.ESC_UP },
+            { type: "wait", ms: 1000 },
+            { type: "chord", keys: [
+              { dn: SC.CTRL_DN, up: SC.CTRL_UP },
+              { dn: SC.ESC_DN, up: SC.ESC_UP },
+            ]},
+            { type: "wait", ms: 1200 },
+            { type: "keys", dn: SC.R_DN, up: SC.R_UP },
+            { type: "wait", ms: 1000 },
+            { type: "text", text: runCmd },
+            { type: "wait", ms: 400 },
+            { type: "keys", dn: SC.ENTER_DN, up: SC.ENTER_UP },
+            ...(runAfter ? [
+              { type: "wait", ms: Number(process.env.WIN95_PROBE_RUN_WAIT) || 6000 },
+              { type: "text", text: runAfter },
+              { type: "wait", ms: 200 },
+              { type: "keys", dn: SC.ENTER_DN, up: SC.ENTER_UP },
+            ] : []),
+          ]);
+        } else {
         console.log("[probe] desktop detected, running script:", scriptCmd);
         runScript(emulator, [
           { type: "wait", ms: 3000 },
@@ -130,6 +160,7 @@ export function startProbe(emulator: any) {
           { type: "wait", ms: 400 },
           { type: "keys", dn: SC.ENTER_DN, up: SC.ENTER_UP },
         ]);
+        }
       }
 
       if (s.verdict) {
@@ -242,7 +273,7 @@ function collectStatus(emulator: any): ProbeStatus {
   // Made it to ≥640×480 graphics → desktop reached. But if a keyboard
   // script is running, hold off — the outer harness reads the SMB log
   // directly and we just keep the app alive.
-  else if (atDesktop && uptimeSec > 30 && !process.env.WIN95_PROBE_SCRIPT) verdict = "SUCCESS";
+  else if (atDesktop && uptimeSec > 30 && !process.env.WIN95_PROBE_SCRIPT && !process.env.WIN95_PROBE_RUN) verdict = "SUCCESS";
   // Timeout
   else if (uptimeSec > 180) verdict = "FAIL_OTHER";
 

--- a/src/renderer/emulator.tsx
+++ b/src/renderer/emulator.tsx
@@ -17,12 +17,17 @@ import { getStatePath } from "./utils/get-state-path";
 import { Win95Window } from "./app";
 import { resetState } from "./utils/reset-state";
 import { setupSmbShare } from "./smb";
+import { setupTcpRelay } from "./net/tcp-relay";
+import { setupDnsShim } from "./net/dns-shim";
 import { startProbe } from "./debug-harness";
 
 const PROBE = process.env.WIN95_PROBE === "1";
 const PROBE_OPTS: Record<string, unknown> = (() => {
-  try { return JSON.parse(process.env.WIN95_PROBE_OPTS || "{}"); }
-  catch { return {}; }
+  try {
+    return JSON.parse(process.env.WIN95_PROBE_OPTS || "{}");
+  } catch {
+    return {};
+  }
 })();
 
 declare let window: Win95Window;
@@ -342,6 +347,9 @@ export class Emulator extends React.Component<{}, EmulatorState> {
       net_device: {
         relay_url: "fetch",
         type: "ne2k",
+        // Real IPs for the guest so the raw-TCP relay knows where to dial;
+        // the default "static" resolver returns a placeholder for every name.
+        dns_method: "doh",
       },
       bios: {
         url: path.join(__dirname, "../../bios/seabios.bin"),
@@ -375,7 +383,14 @@ export class Emulator extends React.Component<{}, EmulatorState> {
 
     console.log(`🚜 Starting emulator with options`, options);
 
+    // Answer the app's magic hostnames locally before v86's DoH path sends
+    // them to Cloudflare (which would NXDOMAIN them).
+    setupDnsShim();
+
     window["emulator"] = new V86(options);
+
+    // Raw TCP egress for ports the fetch adapter ignores (everything but 80).
+    setupTcpRelay(window["emulator"]);
 
     // Serve a host folder over SMB on port 139. Read-only, traversal/symlink
     // guarded. In Win95: Start → Run → \\HOST\HOST. The env var wins so the

--- a/src/renderer/net/dns-shim.ts
+++ b/src/renderer/net/dns-shim.ts
@@ -1,0 +1,81 @@
+// With dns_method:"doh" the guest's UDP/53 queries are POSTed verbatim to
+// cloudflare-dns.com/dns-query. Real DNS can't answer the app's magic names
+// (single-label "windows95", "<port>.external"), which the static resolver
+// used to map to a placeholder IP so the fetch adapter could take over via
+// the Host header. This shim wraps global fetch, spots DoH requests for
+// those names, and answers them locally with the same placeholder; every
+// other lookup goes out to Cloudflare unchanged.
+
+const PLACEHOLDER_IP = [192, 168, 87, 1];
+
+function qnameOf(msg: Uint8Array): string {
+  const labels: string[] = [];
+  let i = 12;
+  while (i < msg.length) {
+    const len = msg[i++];
+    if (len === 0) break;
+    labels.push(String.fromCharCode(...msg.subarray(i, i + len)));
+    i += len;
+  }
+  return labels.join(".");
+}
+
+function isMagicName(name: string): boolean {
+  if (!name.includes(".")) return true; // windows95, host, …
+  if (/^\d+\.external$/i.test(name)) return true; // 8080.external → localhost:8080
+  return false;
+}
+
+function synthAResponse(query: Uint8Array): Uint8Array {
+  // End of the question section: QNAME (null-terminated) + QTYPE(2) + QCLASS(2).
+  let i = 12;
+  while (query[i] !== 0) i += query[i] + 1;
+  const qend = i + 1 + 4;
+
+  const out = new Uint8Array(qend + 16);
+  out.set(query.subarray(0, qend));
+  out[2] = 0x81;
+  out[3] = 0x80; // QR=1 RD=1 RA=1, RCODE=0
+  out[4] = 0;
+  out[5] = 1; // QDCOUNT=1
+  out[6] = 0;
+  out[7] = 1; // ANCOUNT=1
+  out[8] = out[9] = out[10] = out[11] = 0;
+
+  let o = qend;
+  out[o++] = 0xc0;
+  out[o++] = 0x0c; // NAME → pointer to question
+  out[o++] = 0;
+  out[o++] = 1; // TYPE A
+  out[o++] = 0;
+  out[o++] = 1; // CLASS IN
+  out[o++] = 0;
+  out[o++] = 0;
+  out[o++] = 0x02;
+  out[o++] = 0x58; // TTL 600
+  out[o++] = 0;
+  out[o++] = 4; // RDLENGTH
+  out.set(PLACEHOLDER_IP, o);
+  return out;
+}
+
+export function setupDnsShim() {
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/dns-query") && init?.body instanceof Uint8Array) {
+      const q = init.body as Uint8Array;
+      const name = qnameOf(q).toLowerCase();
+      if (isMagicName(name)) {
+        const body = synthAResponse(q);
+        return Promise.resolve(
+          new Response(body as unknown as BodyInit, {
+            status: 200,
+            headers: { "content-type": "application/dns-message" },
+          }),
+        );
+      }
+    }
+    return realFetch(input, init);
+  }) as typeof fetch;
+}

--- a/src/renderer/net/tcp-relay.ts
+++ b/src/renderer/net/tcp-relay.ts
@@ -1,0 +1,118 @@
+// Bridge v86's userspace TCP stack to real host sockets so the guest can
+// reach arbitrary TCP ports — not just the fetch adapter's port-80 HTTP path.
+// We keep relay_url:"fetch" (for DHCP/ARP/ICMP/DNS plumbing and the existing
+// port-80 handling) and simply claim every other SYN on the same bus event.
+//
+// Requires net_device.dns_method:"doh" so the guest resolves real IPs; the
+// default "static" mode hands out 192.168.87.1 for everything, which only
+// works because the fetch adapter re-reads the Host header.
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as net from "net";
+
+interface TCPConnection {
+  sport: number; // dest port the guest connected to
+  psrc: Uint8Array; // dest IP (4 bytes) — "source" from the router's POV
+  tuple: string;
+  net: { tcp_conn: Record<string, unknown> };
+  on(event: "data", handler: (data: Uint8Array) => void): void;
+  write(data: Uint8Array): void;
+  accept(): void;
+  close(): void;
+  on_shutdown: () => void;
+  on_close: () => void;
+}
+
+interface V86 {
+  bus: { register(name: string, fn: (arg: unknown) => void): void };
+}
+
+const LOG_FILE =
+  process.env.WIN95_TCP_RELAY_LOG ||
+  path.join(os.tmpdir(), "win95-tcp-relay.log");
+try {
+  fs.writeFileSync(LOG_FILE, `--- ${new Date().toISOString()} ---\n`);
+} catch {}
+const log = (...a: unknown[]) => {
+  console.log("[tcp-relay]", ...a);
+  try {
+    fs.appendFileSync(LOG_FILE, a.join(" ") + "\n");
+  } catch {}
+};
+
+// Ports already claimed by other in-process handlers.
+const RESERVED_PORTS = new Set([80, 139]);
+
+// Destinations we never relay to. The emulated LAN (192.168.86/87) has nothing
+// real behind it; loopback and link-local would let guest software poke at the
+// host's own services or cloud-metadata endpoints. The rest of RFC1918 is left
+// reachable on purpose — talking to a NAS or BBS on the user's LAN is a
+// legitimate use of this bridge, and the port-80 fetch path already allows it.
+function isBlockedDest(p: Uint8Array): boolean {
+  const [a, b] = p;
+  if (a === 192 && b === 168 && (p[2] === 86 || p[2] === 87)) return true;
+  if (a === 127 || a === 0 || a >= 224) return true; // loopback, "this", multicast+
+  if (a === 169 && b === 254) return true; // link-local / metadata
+  return false;
+}
+
+export function setupTcpRelay(emulator: V86) {
+  emulator.bus.register("tcp-connection", (c: unknown) => {
+    const conn = c as TCPConnection;
+    const port = conn.sport;
+    if (RESERVED_PORTS.has(port)) return;
+    if (isBlockedDest(conn.psrc)) return;
+
+    const ip = Array.from(conn.psrc).join(".");
+
+    // Must accept synchronously or v86 RSTs the SYN right after dispatch.
+    conn.accept();
+    log(`→ ${ip}:${port} (${conn.tuple})`);
+
+    let connected = false;
+    let pending: Buffer[] | null = [];
+    let upstreamGone = false;
+
+    const sock = net.connect({ host: ip, port });
+
+    sock.on("connect", () => {
+      connected = true;
+      if (pending) {
+        for (const b of pending) sock.write(b);
+        pending = null;
+      }
+    });
+    sock.on("data", (d) => conn.write(d));
+    sock.on("close", () => {
+      upstreamGone = true;
+      conn.close();
+    });
+    sock.on("error", (e: NodeJS.ErrnoException) => {
+      log(`✗ ${ip}:${port} ${e.code || e.message}`);
+      upstreamGone = true;
+      conn.close();
+    });
+
+    // tcp_data is a subarray into v86's reused frame buffer — copy before
+    // handing to an async writer.
+    conn.on("data", (d) => {
+      if (d.length === 0) return;
+      const buf = Buffer.from(d);
+      if (connected) sock.write(buf);
+      else pending?.push(buf);
+    });
+
+    const teardown = () => {
+      if (upstreamGone) return;
+      upstreamGone = true;
+      if (connected) sock.end();
+      else sock.destroy();
+    };
+    conn.on_shutdown = teardown;
+    conn.on_close = teardown;
+  });
+
+  log("active — guest TCP to non-80/139 ports is bridged to host sockets");
+}


### PR DESCRIPTION
## What

Let the Win95 guest open real TCP connections to ports other than 80. The fetch network adapter only ever accepted port-80 SYNs (parsing the payload as HTTP and replaying it via `fetch()`); anything else was reset. This adds a second `tcp-connection` bus listener in the renderer that bridges every other destination straight to a Node `net.Socket` — no extra process, no WebSocket/Wisp relay, no new dependencies.

## How

- **`src/renderer/net/tcp-relay.ts`** — accept the SYN synchronously (v86 RSTs otherwise), `net.connect` to `conn.psrc:conn.sport`, buffer guest bytes until the upstream connects, then pipe both ways. Loopback / link-local / multicast are refused so guest software can't poke host services or cloud metadata; the rest of RFC1918 is intentionally left reachable so LAN FTP/telnet/etc keep working. Ports 80 and 139 stay with the existing fetch and SMB handlers.
- **`src/renderer/net/dns-shim.ts`** — `net_device.dns_method` is now `"doh"` so the guest resolves real IPs the relay can dial. Cloudflare can't answer single-label names like `windows95` or the `NNN.external` localhost magic, so this shim wraps global `fetch`, spots `/dns-query` POSTs for those names, and answers with the same `192.168.87.1` placeholder the static resolver used to hand out — the port-80 fetch path then takes over via the Host header exactly as before.
- **`emulator.tsx`** — wire both in alongside the SMB hook; set `dns_method`.
- **`debug-harness.ts`** — `WIN95_PROBE_RUN` / `_RUN_AFTER` / `_RUN_WAIT` to type an arbitrary command into Start → Run (used for the e2e test below).

## Tested

`npm run tsc` clean. End-to-end: booted the guest under the probe harness, ran `telnet 192.168.0.128 7777` against a host-side echo server — relay opened the socket, server received the typed `hi-from-win95` keystrokes, and the guest's Telnet window rendered the server banner (bidirectional). `http://windows95` still serves the bundled static site via the DNS shim.

## Notes

TLS from the guest will tunnel but modern servers reject Win95-era cipher suites, so 443 connecting ≠ HTTPS working. Plaintext protocols (FTP, telnet, IRC, POP3, gopher) are the realistic win here.