### PR TITLE
Make "Start without state" always enabled

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -137,7 +137,6 @@ async function createMenu({ isRunning } = { isRunning: false }) {
         {
           label: "Start without state",
           click: () => send(IPC_COMMANDS.MACHINE_BOOT_FROM_SCRATCH),
-          enabled: !isRunning,
         },
         {
           label: "Restart",

--- a/src/renderer/emulator.tsx
+++ b/src/renderer/emulator.tsx
@@ -314,7 +314,8 @@ export class Emulator extends React.Component<{}, EmulatorState> {
   /**
    * Boot the emulator without restoring state
    */
-  public bootFromScratch() {
+  public async bootFromScratch() {
+    await this.stopEmulator();
     this.setState({ isBootingFresh: true });
     this.startEmulator();
   }


### PR DESCRIPTION
Follow-up to #357.

Removes the `enabled: !isRunning` gate so **Machine → Start without state** is clickable at any time. `bootFromScratch()` now awaits `stopEmulator()` first — a no-op when stopped, and a clean save-state + teardown when running — before starting a fresh boot.