### PR TITLE
Wait for v86 emulator-loaded before restoring state

### DIFF
--- a/src/renderer/emulator.tsx
+++ b/src/renderer/emulator.tsx
@@ -482,17 +482,16 @@ export class Emulator extends React.Component<{}, EmulatorState> {
 
     ipcRenderer.send(IPC_COMMANDS.MACHINE_STARTED);
 
-    // Restore state. We can't do this right away
-    // and randomly chose 500ms as the appropriate
-    // wait time (lol)
-    setTimeout(async () => {
+    // Wait for v86 to finish loading wasm/bios/hda before restoring — calling
+    // restore_state on an uninitialized cpu throws and we'd silently cold-boot.
+    window["emulator"].add_listener("emulator-loaded", async () => {
       if (!this.state.isBootingFresh) {
         await this.restoreState();
       }
 
-      this.state.emulator.run();
-      this.state.emulator.screen_set_scale(this.state.scale);
-    }, 500);
+      window["emulator"].run();
+      window["emulator"].screen_set_scale(this.state.scale);
+    });
   }
 
   /**


### PR DESCRIPTION
## Problem

Sessions intermittently fail to resume from saved state in packaged builds — the app cold-boots from `default-state.bin` instead of the user's `state-v5.bin`.

## Cause

`startEmulator()` used a hardcoded `setTimeout(500)` before calling `restore_state()`. This races against v86's async wasm/BIOS/hda load. In dev the files are warm in cache (~170ms measured), so 500ms is plenty. In a packaged app launched cold — Gatekeeper scan, cold filesystem cache, slower disk — loading can exceed 500ms, `restore_state` runs on an uninitialized CPU, throws, gets silently caught, and `emulator.run()` proceeds from a cold boot.

## Fix

Replace the timer with v86's `emulator-loaded` event, which fires exactly once after wasm + BIOS + hda are fully initialized. The listener is registered synchronously after `new V86()` so it can't miss the event (file loads are always async).

## Testing

Instrumented build, launched Electron with an existing 86MB `state-v5.bin`:
- `emulator-loaded` fired at 171ms
- `restore_state` succeeded
- CPU resumed at 563M instructions (mid-session, not POST)
- save-on-quit still writes state correctly