### PR TITLE
Add npm run qemu / qemu:cdrom scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "lint": "prettier --write src/**/*.{ts,tsx} && npm run check-links",
     "tsc": "tsc -p tsconfig.json --noEmit",
     "check-links": "node tools/check-links.js",
+    "qemu": "qemu-system-i386 -m 128 -drive file=images/windows95.img,format=raw -device sb16 -M pc,acpi=off,vmport=on -cpu pentium -netdev user,id=mynet0 -device ne2k_isa,netdev=mynet0,iobase=0x300,irq=10",
+    "qemu:cdrom": "npm run qemu -- -cdrom",
     "postinstall": "patch-package"
   },
   "keywords": [],


### PR DESCRIPTION
Adds two convenience scripts for booting `images/windows95.img` in QEMU with the device set the image is actually configured for.

## `npm run qemu`
```
qemu-system-i386 -m 128 -drive file=images/windows95.img,format=raw \
  -device sb16 -M pc,acpi=off,vmport=on -cpu pentium \
  -netdev user,id=mynet0 -device ne2k_isa,netdev=mynet0,iobase=0x300,irq=10
```

- **`ne2k_isa,iobase=0x300,irq=10`** — matches the `*PNP80D6` ForcedConfig baked into `SYSTEM.DAT` (and v86, whose ne2k sits at port `0x300` with PIRQA→IRQ 10). Using `ne2k_pci` here makes Win95 pop the *"NE2000 Compatible (0000) is not working properly"* dialog.
- **`vmport=on`** — explicit so VBMouse's VMware-backdoor detection finds it (`Found VMware protocol version 6` / `VMware integration enabled`); QEMU's monitor then shows `* vmmouse (absolute)` as the active pointer.
- **`-drive ...,format=raw`** instead of `-hda` to drop the "probing guessed raw" write-restriction warning.

## `npm run qemu:cdrom -- <iso>`
Same boot plus `-cdrom <iso>`, e.g. for mounting an installer ISO as D:.