### PR TITLE
Fix SMB transfer hang: cap TCP burst at 4×MSS

### DIFF
--- a/src/renderer/smb/index.ts
+++ b/src/renderer/smb/index.ts
@@ -142,8 +142,10 @@ export function setupSmbShare(emulator: V86, hostPath: string | null, toolsRoot?
     }
 
     // v86's TCP is stop-and-wait (one MSS, wait for ACK). The link is lossless
-    // and has no retransmit anyway, so keep a window in flight by sliding the
-    // ring-buffer view under the original pump(). 8×MSS cap ≈ NE2000 RX ring.
+    // and has no retransmit anyway, so keep a small window in flight by sliding
+    // the ring-buffer view under the original pump(). The burst lands in the
+    // NE2000 RX ring before the guest CPU runs, so the cap is the ring (52–58
+    // pages for Win95's driver) — 4×MSS + our ACK ≈ 36 pages, 8 overflowed it.
     const c = conn as any, sb = c.send_buffer;
     const mss: number = c.send_chunk_buf?.length ?? 1460;
     const pump1 = Object.getPrototypeOf(c)?.pump;
@@ -152,7 +154,7 @@ export function setupSmbShare(emulator: V86, hostPath: string | null, toolsRoot?
       c.pump = function () {
         if (this.pending || !sb.length) return pump1.call(this);
         const cap = sb.buffer.length, t0 = sb.tail, l0 = sb.length, s0 = this.seq;
-        const win = Math.max(mss, Math.min(this.winsize || 8192, 8 * mss));
+        const win = 4 * mss;
         let off = hi === undefined ? 0 : Math.max(0, Math.min(hi - s0, l0));
         for (; off < l0 && off < win; off += Math.min(mss, l0 - off)) {
           sb.tail = (t0 + off) % cap; sb.length = l0 - off;


### PR DESCRIPTION
Follow-up to #370 — the 8×MSS burst overflowed the NE2000 RX ring.

The pump() override sends its whole burst synchronously (the guest CPU doesn't run between `net.receive()` calls), so every frame lands in the NE2000 ring before Win95 reads any of them. `Dc.prototype.receive` silently discards on overflow, v86 has no retransmit, and the override's `hi` cursor has already advanced past the dropped bytes — Win95 dup-ACKs into the void and the redirector eventually reports "network resource is no longer available".

Win95's NE2000 driver gives the RX ring 52–58 pages. 8×MSS (+the loop's one-segment overshoot) plus our preceding ACK is ~10 frames ≈ 60 pages; 4×MSS + ACK is ~36. Dropped the `winsize` clamp too — it's captured once from the SYN and never updated, so it was always 8192 anyway.