### PR TITLE
Degrade gracefully when the shared folder no longer exists

### DIFF
--- a/src/renderer/emulator.tsx
+++ b/src/renderer/emulator.tsx
@@ -495,8 +495,27 @@ export class Emulator extends React.Component<{}, EmulatorState> {
     // probe harness can point at a fixture dir without touching settings.
     // The hook is installed unconditionally so the Machine ▸ Change Shared
     // Folder menu can point it at a directory later without a restart.
-    const smbRoot =
+    //
+    // The saved path is validated when it's set (SET_SMB_SHARE_PATH in
+    // src/main/ipc.ts), but the directory can be deleted afterwards. The SMB
+    // server degrades gracefully either way; checking here too means a stale
+    // path boots as "no folder shared" (\\HOST\TOOLS still works) and the
+    // warning below tells the user why their share is missing.
+    const savedSmbRoot =
       process.env.WIN95_SMB_SHARE || this.state.smbSharePath || null;
+    let smbRoot = savedSmbRoot;
+    if (smbRoot) {
+      try {
+        if (!fs.statSync(smbRoot).isDirectory()) smbRoot = null;
+      } catch {
+        smbRoot = null;
+      }
+      if (!smbRoot) {
+        console.warn(
+          `🗂 Shared folder no longer exists, starting without it: ${savedSmbRoot}`,
+        );
+      }
+    }
     this.smbShare = setupSmbShare(
       window["emulator"],
       smbRoot,

--- a/src/renderer/smb/README.md
+++ b/src/renderer/smb/README.md
@@ -35,6 +35,14 @@ mounted folder (sanitized, ≤12 chars). `TOOLS` is purely synthetic — `_MAPZ.
 share name to a TID; every path-resolving handler branches on TID so the TOOLS
 tree never touches the host fs.
 
+The user share's backing directory is re-validated on every TREE_CONNECT and
+NetShareEnum (it can be deleted — or restored — at any time after the path was
+saved in settings). While it's missing, connects to that share return
+ERRSRV/ERRinvnetname ("network name cannot be found"), the share is hidden from
+enumeration, and TOOLS/IPC$ keep working. `SmbSession` accepts a null root for
+the "no folder configured" case and must never throw from its constructor — see
+the bus-listener note below.
+
 ### SEARCH (0x81): single-file probes vs wildcard listings
 `SEARCH "\FOO.TXT"` is a stat probe — Win95 wants exactly one entry back. If you
 prepend `.` and `..` like you would for `\*`, Win95 reads the first entry (`.`,
@@ -85,8 +93,21 @@ Clean API. The new code keeps both paths; the bus event is a no-op on old builds
 
 ### Exception in a bus listener kills the emulator
 `bus.send` doesn't catch listener exceptions. They bubble through ne2k →
-`port_write8` → wasm. Win95 freezes. The corrupted state then gets saved by
-`onbeforeunload`. Wrap everything that runs in a callback.
+`port_write8` → wasm and unwind `do_tick()` before it can schedule
+`next_tick()` — the whole VM freezes (instruction counter stops, CPU not
+halted), not just SMB. The corrupted state then gets saved by
+`onbeforeunload`. Wrap everything that runs in a callback:
+
+- the `tcp-connection` bus handler and the old-API `on_tcp_connection` hook
+  (`index.ts`) are wrapped in try/catch — any failure declines the connection,
+- the per-connection data handler (`index.ts`) drops the frame instead,
+- the NBNS `net0-send` handler (`nbns.ts`) drops the frame instead,
+- `SmbSession`'s constructor never throws (a stale share root degrades to
+  per-tree SMB errors; see "Shares" above).
+
+This was a real bug: a share path deleted after being saved made
+`new SmbSession` throw ENOENT inside the tick on the guest's first port-139
+SYN, freezing the entire VM seconds after every boot.
 
 ## Security
 - Read-only.
@@ -94,10 +115,13 @@ Clean API. The new code keeps both paths; the bus event is a no-op on old builds
   the deepest existing ancestor, re-append the unresolved tail, confirm under
   root. Symlinks pointing inside the share still work; symlinks pointing out
   return ERR_BADFILE.
-- Share path validated in main-process IPC (`realpathSync` + `isDirectory()`).
+- Share path validated in main-process IPC (`realpathSync` + `isDirectory()`),
+  re-checked at emulator startup (`emulator.tsx`), and re-resolved on every
+  TREE_CONNECT — a directory deleted after being saved degrades to SMB errors
+  instead of crashing.
 
 ## Tests
-`test-standalone.ts` — 55 protocol tests, full round-trips with real file I/O.
+`test-standalone.ts` — 76 protocol tests, full round-trips with real file I/O.
 Run: `npx ts-node --skip-project --transpile-only --compiler-options
 '{"module":"commonjs","moduleResolution":"bundler","ignoreDeprecations":"6.0"}'
 src/renderer/smb/test-standalone.ts`

--- a/src/renderer/smb/index.ts
+++ b/src/renderer/smb/index.ts
@@ -111,24 +111,27 @@ export function setupSmbShare(emulator: V86, hostPath: string | null, toolsRoot?
 
   const wireConn = (conn: TCPConnection) => {
     log(`← TCP SYN ${conn.tuple}`);
-    if (!hostPath) {
-      // No folder picked yet — caller declines the SYN so the guest sees a
-      // clean RST instead of a half-open NetBIOS session.
-      log("no share configured → RST");
-      return false;
-    }
+    // hostPath may be null (no folder picked yet) or stale (directory deleted
+    // since it was saved). SmbSession handles both: \\HOST\TOOLS keeps
+    // working, the user share answers with "network name not found".
     const framer = new NetBIOSFramer();
     const session = new SmbSession(hostPath, toolsRoot);
 
     const handler = (data: Uint8Array) => {
-      for (const msg of framer.push(data)) {
-        if (msg.type === 0x81) {
-          log("← NB session request → +response");
-          conn.write(nbPositiveResponse());
-        } else if (msg.type === 0x00) {
-          const reply = session.handle(msg.payload);
-          if (reply) conn.write(nbWrap(reply));
+      // Runs inside v86's do_tick() (guest TX → ne2k → fake_network) — an
+      // exception escaping here would kill the tick chain and freeze the VM.
+      try {
+        for (const msg of framer.push(data)) {
+          if (msg.type === 0x81) {
+            log("← NB session request → +response");
+            conn.write(nbPositiveResponse());
+          } else if (msg.type === 0x00) {
+            const reply = session.handle(msg.payload);
+            if (reply) conn.write(nbWrap(reply));
+          }
         }
+      } catch (e) {
+        log("⚠ data handler threw — dropping frame:", e);
       }
     };
 
@@ -170,9 +173,18 @@ export function setupSmbShare(emulator: V86, hostPath: string | null, toolsRoot?
 
   // New API: bus event (no-op on old v86 — event never fires)
   emulator.bus.register("tcp-connection", (c: unknown) => {
-    const conn = c as TCPConnection;
-    if (conn.sport !== 139) return;
-    if (wireConn(conn)) conn.accept();
+    // Backstop: this callback runs synchronously inside v86's do_tick()
+    // (guest SYN → ne2k transmit → fake_network → bus.send), and bus.send
+    // doesn't catch listener exceptions. Anything escaping here unwinds
+    // do_tick() before it can schedule next_tick() — the whole VM freezes,
+    // not just SMB. Drop the connection instead.
+    try {
+      const conn = c as TCPConnection;
+      if (conn.sport !== 139) return;
+      if (wireConn(conn)) conn.accept();
+    } catch (e) {
+      log("⚠ tcp-connection hook threw — connection dropped:", e);
+    }
   });
 
   // Old API: monkey-patch adapter.on_tcp_connection. The adapter is created
@@ -191,43 +203,51 @@ export function setupSmbShare(emulator: V86, hostPath: string | null, toolsRoot?
     const orig = adapter.on_tcp_connection.bind(adapter);
     adapter.on_tcp_connection = function (packet: any, tuple: string): boolean {
       if (packet.tcp.dport !== 139) return orig(packet, tuple);
-      // New v86 fires the tcp-connection bus event BEFORE this callback;
-      // if our bus handler already accepted the conn, it's in tcp_conn —
-      // claim it so the original (which would otherwise RST) doesn't run.
-      if (adapter.tcp_conn[tuple]) return true;
-
-      const adapterAny = adapter as any;
-      adapterAny.receive = () => {};
-      let conn: TCPConnection | undefined;
+      // Backstop: like the tcp-connection bus event above, this is called
+      // from inside v86's do_tick(). An uncaught exception here freezes the
+      // whole VM, so any failure becomes "decline the SYN" (guest sees RST).
       try {
-        const fakeTuple = "__nbt__";
-        orig({ ...packet, tcp: { ...packet.tcp, dport: 80 } }, fakeTuple);
-        conn = adapter.tcp_conn[fakeTuple];
-        delete adapter.tcp_conn[fakeTuple];
-      } finally {
-        delete adapterAny.receive;
-      }
+        // New v86 fires the tcp-connection bus event BEFORE this callback;
+        // if our bus handler already accepted the conn, it's in tcp_conn —
+        // claim it so the original (which would otherwise RST) doesn't run.
+        if (adapter.tcp_conn[tuple]) return true;
 
-      if (!conn) {
-        log("⚠ probe didn't yield a connection; RST");
-        return false;
-      }
+        const adapterAny = adapter as any;
+        adapterAny.receive = () => {};
+        let conn: TCPConnection | undefined;
+        try {
+          const fakeTuple = "__nbt__";
+          orig({ ...packet, tcp: { ...packet.tcp, dport: 80 } }, fakeTuple);
+          conn = adapter.tcp_conn[fakeTuple];
+          delete adapter.tcp_conn[fakeTuple];
+        } finally {
+          delete adapterAny.receive;
+        }
 
-      // Re-aim it at port 139. accept() overwrites sport/dport/hsrc/psrc/seq/ack
-      // from the packet; .on("data") replaces the HTTP handler (assignment, not
-      // push). Only state needs explicit reset — the probe accept set it to
-      // "established" and we want a fresh handshake.
-      conn.tuple = tuple;
-      conn.state = "syn-received";
-      if (!wireConn(conn)) return false;
-      try {
-        conn.accept(packet);
+        if (!conn) {
+          log("⚠ probe didn't yield a connection; RST");
+          return false;
+        }
+
+        // Re-aim it at port 139. accept() overwrites sport/dport/hsrc/psrc/seq/ack
+        // from the packet; .on("data") replaces the HTTP handler (assignment, not
+        // push). Only state needs explicit reset — the probe accept set it to
+        // "established" and we want a fresh handshake.
+        conn.tuple = tuple;
+        conn.state = "syn-received";
+        if (!wireConn(conn)) return false;
+        try {
+          conn.accept(packet);
+        } catch (e) {
+          log("accept threw:", e instanceof Error ? e.message : String(e));
+          return false;
+        }
+        adapter.tcp_conn[tuple] = conn;
+        return true;
       } catch (e) {
-        log("accept threw:", e instanceof Error ? e.message : String(e));
+        log("⚠ on_tcp_connection hook threw — RST:", e);
         return false;
       }
-      adapter.tcp_conn[tuple] = conn;
-      return true;
     };
     log("hooked adapter.on_tcp_connection (old API, conn-recycling)");
     return true;

--- a/src/renderer/smb/nbns.ts
+++ b/src/renderer/smb/nbns.ts
@@ -31,13 +31,20 @@ interface V86 {
 
 export function setupNbns(emulator: V86) {
   emulator.bus.register("net0-send", (frame: Uint8Array) => {
-    const r = parseUdp(frame);
-    if (!r || r.dport !== NBNS_PORT) return;
+    // Runs inside v86's do_tick() (NIC transmit → bus.send), which has no
+    // exception handling — an uncaught throw here would kill the emulator's
+    // tick chain and freeze the whole VM. Drop the frame instead.
+    try {
+      const r = parseUdp(frame);
+      if (!r || r.dport !== NBNS_PORT) return;
 
-    const reply = handleNbns(r.payload, emulator);
-    if (reply) {
-      const eth = buildUdpFrame(emulator, r, NBNS_PORT, r.sport, reply);
-      emulator.bus.send("net0-receive", eth);
+      const reply = handleNbns(r.payload, emulator);
+      if (reply) {
+        const eth = buildUdpFrame(emulator, r, NBNS_PORT, r.sport, reply);
+        emulator.bus.send("net0-receive", eth);
+      }
+    } catch (e) {
+      log("⚠ NBNS handler threw — dropping frame:", e);
     }
   });
   log(`listening on UDP 137 — answering as "${NB_NAME}"`);

--- a/src/renderer/smb/server.ts
+++ b/src/renderer/smb/server.ts
@@ -12,6 +12,7 @@ import {
   CMD_QUERY_INFORMATION, CMD_FIND_CLOSE2, CMD_CHECK_DIRECTORY, CMD_SEARCH,
   TRANS2_FIND_FIRST2, TRANS2_FIND_NEXT2, TRANS2_QUERY_FS_INFO, TRANS2_QUERY_PATH_INFO,
   ERRDOS, ERRSRV, ERR_BADFILE, ERR_BADPATH, ERR_BADFID, ERR_NOFILES, ERR_BADFUNC,
+  ERR_INVNETNAME,
 } from "./smb";
 
 const log = (...a: unknown[]) => console.log("[smb]", ...a);
@@ -109,7 +110,14 @@ export class SmbSession {
   // 8.3 → real name, per host directory. SEARCH builds this; OPEN/QUERY
   // consult it so clicking "15UNDE~2.PDF" finds the right long-named file.
   private sfnMaps = new Map<string, Map<string, string>>();
-  private readonly realRoot: string;
+  // The user share's configured path (may be null: no folder picked) and its
+  // resolved realpath (null while the directory doesn't exist). The realpath
+  // is re-derived on every TREE_CONNECT — the directory can be deleted (or
+  // reappear) at any time after the path was saved, and a stale path must
+  // degrade to SMB errors on this share, never an exception: this code runs
+  // inside v86's tick, where an uncaught throw freezes the whole VM.
+  private readonly rootPath: string | null;
+  private realRoot: string | null;
   private readonly toolsRoot?: string;
   public readonly shareName: string;
   public capture = !!process.env.WIN95_SMB_CAPTURE;
@@ -121,9 +129,14 @@ export class SmbSession {
   // makes the mapping survive reboots.
   private readonly virtuals: Map<string, Uint8Array>;
 
-  constructor(rootPath: string, toolsRoot?: string) {
-    this.realRoot = fs.realpathSync(rootPath);
-    this.shareName = shareNameFor(this.realRoot);
+  constructor(rootPath: string | null, toolsRoot?: string) {
+    // Never throws: a saved share path can point at a directory that was
+    // deleted after it was saved. realRoot just stays null and the user
+    // share answers with SMB errors while TOOLS keeps working.
+    this.rootPath = rootPath;
+    this.realRoot = rootPath ? safeRealpathDir(rootPath) : null;
+    this.shareName = shareNameFor(this.realRoot ?? rootPath ?? "");
+    const userShareLabel = this.realRoot ?? rootPath ?? "(no folder shared)";
     const enc = (s: string) => new TextEncoder().encode(s);
     this.virtuals = new Map([
       ["README.TXT", enc(
@@ -131,7 +144,7 @@ export class SmbSession {
         "----------------\r\n" +
         "These files are served by the windows95 app from\r\n" +
         `  ${toolsRoot ?? "(in-memory)"}\r\n\r\n` +
-        `  \\\\HOST\\${this.shareName.padEnd(12)} your shared folder (${this.realRoot})\r\n` +
+        `  \\\\HOST\\${this.shareName.padEnd(12)} your shared folder (${userShareLabel})\r\n` +
         `  \\\\HOST\\${TOOLS_SHARE.padEnd(12)} this folder\r\n\r\n` +
         "_MAPZ.BAT   maps your shared folder to drive Z:. Copy it to\r\n" +
         "            C:\\WINDOWS\\Start Menu\\Programs\\StartUp to reconnect\r\n" +
@@ -146,9 +159,17 @@ export class SmbSession {
         "PAUSE\r\n"
       )],
     ]);
-    this.toolsRoot = toolsRoot && fs.existsSync(toolsRoot)
-      ? fs.realpathSync(toolsRoot)
-      : undefined;
+    this.toolsRoot = toolsRoot ? (safeRealpathDir(toolsRoot) ?? undefined) : undefined;
+  }
+
+  /**
+   * Re-resolve the user share's backing directory and cache the result.
+   * Called on every TREE_CONNECT and share enumeration so a directory that
+   * vanishes (or comes back) is picked up without restarting the session.
+   */
+  private refreshUserRoot(): string | null {
+    this.realRoot = this.rootPath ? safeRealpathDir(this.rootPath) : null;
+    return this.realRoot;
   }
 
   private getVirtual(tid: number, smbPath: string): Uint8Array | undefined {
@@ -381,7 +402,19 @@ export class SmbSession {
     // so W95TOOLS.EXE can hard-code \\HOST\HOST when it auto-maps Z:.
     const share = reqPath.split(/[\\\/]/).pop()?.toUpperCase() ?? "";
     const isIpc = share === "IPC$";
-    this.tid = isIpc ? TID_IPC : share === TOOLS_SHARE ? TID_TOOLS : TID_SHARE;
+    const tid = isIpc ? TID_IPC : share === TOOLS_SHARE ? TID_TOOLS : TID_SHARE;
+
+    // The user share's backing directory is re-validated on every connect —
+    // it may have been deleted (or restored) since the session started. A
+    // missing root refuses just this tree with "network name not found";
+    // TOOLS and IPC$ stay connectable so W95TOOLS' automatic
+    // `NET USE Z: \\HOST\HOST` fails cleanly instead of wedging the server.
+    if (tid === TID_SHARE && !this.refreshUserRoot()) {
+      log(`tree connect: share root unavailable (${this.rootPath ?? "none configured"})`);
+      return buildSmb(req, CMD_TREE_CONNECT_ANDX, dosError(ERRSRV, ERR_INVNETNAME),
+                      new Uint8Array(0), new Uint8Array(0));
+    }
+    this.tid = tid;
 
     const words = new Writer()
       .bytes(andxNone())
@@ -1167,7 +1200,9 @@ export class SmbSession {
       //   W   = 2-byte type (0=disk, 3=IPC)
       //   z   = 4-byte string pointer (we send 0 = no remark)
       const shares = [
-        { name: this.shareName, type: 0 },
+        // Hide the user share while its backing directory is missing —
+        // listing a share that refuses every connect just confuses Explorer.
+        ...(this.refreshUserRoot() ? [{ name: this.shareName, type: 0 }] : []),
         { name: TOOLS_SHARE, type: 0 },
         { name: "IPC$", type: 3 },
       ];
@@ -1269,6 +1304,20 @@ export class SmbSession {
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * realpath a directory without ever throwing. Returns null when the path
+ * doesn't exist, isn't a directory, or can't be resolved — callers treat
+ * that as "this share has no backing directory right now".
+ */
+export function safeRealpathDir(p: string): string | null {
+  try {
+    const real = fs.realpathSync(p);
+    return fs.statSync(real).isDirectory() ? real : null;
+  } catch {
+    return null;
+  }
+}
 
 // DOS device names. Win95 maps these regardless of extension or directory,
 // so a host file called "con.txt" or "AUX" opens the device and hangs the

--- a/src/renderer/smb/smb.ts
+++ b/src/renderer/smb/smb.ts
@@ -47,6 +47,10 @@ export const ERR_NOACCESS = 0x0005;
 export const ERR_BADFID = 0x0006;
 export const ERR_NOFILES = 0x0012; // no more files
 export const ERR_BADFUNC = 0x0001; // unsupported
+// ERRSRV-class code: share name doesn't exist on this server. Win95 reports
+// it as "The network name cannot be found" — what we want when the user
+// share's backing directory has been deleted out from under us.
+export const ERR_INVNETNAME = 0x0006;
 
 // Flags
 const FLAGS_REPLY = 0x80;

--- a/src/renderer/smb/test-standalone.ts
+++ b/src/renderer/smb/test-standalone.ts
@@ -464,6 +464,172 @@ console.log("\n[7] Error handling");
   ok(parsed.status === 0, "internal symlink allowed");
 }
 
+// ─── Test 8: stale share root ────────────────────────────────────────────────
+// Regression: settings.json can point at a directory that was deleted after
+// being saved. SmbSession is constructed inside v86's tcp-connection bus
+// callback (inside do_tick), so it must NEVER throw — a stale root has to
+// degrade to SMB errors on the user share while \\HOST\TOOLS keeps working.
+console.log("\n[8] Stale share root (directory never existed)");
+{
+  const ghostRoot = path.join(os.tmpdir(), `smbtest-ghost-${process.pid}`);
+  // (intentionally never created)
+
+  let stale: SmbSession | undefined;
+  let threw: unknown = null;
+  try {
+    stale = new SmbSession(ghostRoot);
+  } catch (e) {
+    threw = e;
+  }
+  ok(!threw, `constructor doesn't throw on missing root (got: ${threw})`);
+
+  if (stale) {
+    stale.capture = false;
+
+    // NEGOTIATE + SESSION_SETUP still work
+    const negBytes: number[] = [];
+    for (const d of ["LANMAN2.1", "NT LM 0.12"]) { negBytes.push(0x02); negBytes.push(...cstr(d)); }
+    const neg = parseSmb(stale.handle(smbReq(CMD_NEGOTIATE, [], negBytes))!)!;
+    ok(neg.status === 0, "NEGOTIATE OK");
+
+    const ssWords = [0xff, 0, 0, 0, ...u16(4096), ...u16(1), ...u16(0),
+                     ...u32(0), ...u16(0), ...u32(0)];
+    const ssBytes = [...cstr(""), ...cstr("GUEST"), ...cstr("WORKGROUP"),
+                     ...cstr("Windows 4.0"), ...cstr("Windows 4.0")];
+    const ss = parseSmb(stale.handle(smbReq(CMD_SESSION_SETUP_ANDX, ssWords, ssBytes))!)!;
+    ok(ss.status === 0, "SESSION_SETUP OK");
+
+    // TREE_CONNECT to the user share → SMB error (ERRSRV/ERRinvnetname), not a crash
+    const tcWords = [0xff, 0, 0, 0, ...u16(0), ...u16(1)];
+    const tc = parseSmb(stale.handle(smbReq(CMD_TREE_CONNECT_ANDX, tcWords,
+      [0, ...cstr("\\\\HOST\\HOST"), ...cstr("?????")], 0, 1))!)!;
+    ok(tc.status !== 0, `user share connect → status=0x${tc.status.toString(16)}`);
+    // DOS error: class=2 (ERRSRV), code=6 (ERRinvnetname)
+    ok((tc.status & 0xff) === 2 && (tc.status >> 16) === 6, "ERRSRV/ERRinvnetname");
+
+    // TOOLS still fully works: connect, open a virtual file, read it
+    const tcTools = parseSmb(stale.handle(smbReq(CMD_TREE_CONNECT_ANDX, tcWords,
+      [0, ...cstr("\\\\HOST\\TOOLS"), ...cstr("?????")], 0, 1))!)!;
+    ok(tcTools.status === 0 && tcTools.tid === 2, `TOOLS connect OK (tid=${tcTools.tid})`);
+
+    const oWords = [0xff, 0, 0, 0, ...u16(0), ...u16(0), ...u16(0), ...u16(0),
+                    ...u32(0), ...u16(1), ...u32(0), ...u32(0), ...u32(0)];
+    const o = parseSmb(stale.handle(smbReq(CMD_OPEN_ANDX, oWords,
+      [...cstr("\\_MAPZ.BAT")], tcTools.tid, 1))!)!;
+    ok(o.status === 0, "open virtual _MAPZ.BAT on TOOLS OK");
+    const fid = o.words[4] | (o.words[5] << 8);
+    const r = parseSmb(stale.handle(smbReq(CMD_READ_ANDX,
+      [0xff, 0, 0, 0, ...u16(fid), ...u32(0), ...u16(500), ...u16(0), ...u32(0), ...u16(0)],
+      [], tcTools.tid, 1))!)!;
+    const rLen = r.words[10] | (r.words[11] << 8);
+    const rText = String.fromCharCode(...r.bytes.slice(1, 1 + rLen));
+    ok(rText.includes("NET USE Z:"), "read virtual _MAPZ.BAT on TOOLS OK");
+
+    // RAP NetShareEnum hides the dead user share but still lists TOOLS
+    const ipc = parseSmb(stale.handle(smbReq(CMD_TREE_CONNECT_ANDX, tcWords,
+      [0, ...cstr("\\\\HOST\\IPC$"), ...cstr("IPC")], 0, 1))!)!;
+    ok(ipc.status === 0 && ipc.tid === 0xfffe, "IPC$ connect OK");
+    const rap = [...u16(0), ...cstr("WrLeh"), ...cstr("B13BWz"), ...u16(1), ...u16(4096)];
+    const rapName = cstr("\\PIPE\\LANMAN");
+    const rapBytesStart = 32 + 1 + 14 * 2 + 2;
+    const rapWords = [
+      ...u16(rap.length), ...u16(0), ...u16(100), ...u16(4096),
+      0, 0, ...u16(0), ...u32(0), ...u16(0),
+      ...u16(rap.length), ...u16(rapBytesStart + rapName.length),
+      ...u16(0), ...u16(0),
+      0, 0,
+    ];
+    const enumReply = parseSmb(stale.handle(
+      smbReq(0x25, rapWords, [...rapName, ...rap], ipc.tid, 1))!)!;
+    const enumStr = String.fromCharCode(...enumReply.bytes);
+    ok(enumStr.includes("TOOLS"), "NetShareEnum still lists TOOLS");
+    // The ghost share would be named SMBTEST-GHOS… (basename, 12-char cap) —
+    // make sure it's hidden
+    ok(!enumStr.toUpperCase().includes("SMBTEST"), "NetShareEnum hides the dead user share");
+
+    stale.destroy();
+  }
+}
+
+// ─── Test 8b: no share configured at all ────────────────────────────────────
+console.log("\n[8b] No share configured (rootPath=null)");
+{
+  const noShare = new SmbSession(null);
+  noShare.capture = false;
+  const tcWords = [0xff, 0, 0, 0, ...u16(0), ...u16(1)];
+  const tc = parseSmb(noShare.handle(smbReq(CMD_TREE_CONNECT_ANDX, tcWords,
+    [0, ...cstr("\\\\HOST\\HOST"), ...cstr("?????")], 0, 1))!)!;
+  ok((tc.status & 0xff) === 2 && (tc.status >> 16) === 6,
+     "user share connect → ERRSRV/ERRinvnetname");
+  const tcTools = parseSmb(noShare.handle(smbReq(CMD_TREE_CONNECT_ANDX, tcWords,
+    [0, ...cstr("\\\\HOST\\TOOLS"), ...cstr("?????")], 0, 1))!)!;
+  ok(tcTools.status === 0 && tcTools.tid === 2, "TOOLS still connectable");
+  noShare.destroy();
+}
+
+// ─── Test 9: share root deleted mid-session ─────────────────────────────────
+console.log("\n[9] Share root deleted (and restored) mid-session");
+{
+  const findFirstReq = (tid: number, pattern: string): Uint8Array => {
+    const t2params = [...u16(0x16), ...u16(100), ...u16(0), ...u16(1),
+                      ...u32(0), ...cstr(pattern)];
+    const wc = 14 + 1;
+    const bytesStart = 32 + 1 + wc * 2 + 2;
+    const paramOff = bytesStart + 3;
+    const words = [
+      ...u16(t2params.length), ...u16(0), ...u16(100), ...u16(8000),
+      1, 0, ...u16(0), ...u32(0), ...u16(0),
+      ...u16(t2params.length), ...u16(paramOff),
+      ...u16(0), ...u16(0),
+      1, 0, ...u16(1),
+    ];
+    return smbReq(CMD_TRANSACTION2, words, [0, 0, 0, ...t2params], tid, 1);
+  };
+
+  const vanishRoot = fs.mkdtempSync(path.join(os.tmpdir(), "smbtest-vanish-"));
+  fs.writeFileSync(path.join(vanishRoot, "x.txt"), "x");
+  const s = new SmbSession(vanishRoot);
+  s.capture = false;
+
+  const tcWords = [0xff, 0, 0, 0, ...u16(0), ...u16(1)];
+  const tcBytes = [0, ...cstr("\\\\HOST\\HOST"), ...cstr("?????")];
+  const tc1 = parseSmb(s.handle(smbReq(CMD_TREE_CONNECT_ANDX, tcWords, tcBytes, 0, 1))!)!;
+  ok(tc1.status === 0, "tree connect OK while root exists");
+  const tid = tc1.tid;
+
+  // Delete the directory out from under the connected session
+  fs.rmSync(vanishRoot, { recursive: true });
+
+  let threw: unknown = null;
+  let listReply: Uint8Array | null = null;
+  try {
+    listReply = s.handle(findFirstReq(tid, "\\*"));
+  } catch (e) {
+    threw = e;
+  }
+  ok(!threw, `FIND_FIRST2 after deletion doesn't throw (got: ${threw})`);
+  ok(!!listReply && parseSmb(listReply)!.status !== 0,
+     "FIND_FIRST2 after deletion → SMB error");
+
+  // Reconnect attempt → refused with ERRinvnetname
+  const tc2 = parseSmb(s.handle(smbReq(CMD_TREE_CONNECT_ANDX, tcWords, tcBytes, 0, 1))!)!;
+  ok((tc2.status & 0xff) === 2 && (tc2.status >> 16) === 6,
+     "re-connect after deletion → ERRSRV/ERRinvnetname");
+
+  // Directory comes back (e.g. user re-creates it) → next connect works again
+  fs.mkdirSync(vanishRoot);
+  fs.writeFileSync(path.join(vanishRoot, "back.txt"), "hi");
+  const tc3 = parseSmb(s.handle(smbReq(CMD_TREE_CONNECT_ANDX, tcWords, tcBytes, 0, 1))!)!;
+  ok(tc3.status === 0, "connect after directory restored → OK");
+  const list3 = parseSmb(s.handle(findFirstReq(tc3.tid, "\\*"))!)!;
+  ok(list3.status === 0 &&
+     String.fromCharCode(...list3.bytes).includes("back.txt"),
+     "listing works again after restore");
+
+  s.destroy();
+  fs.rmSync(vanishRoot, { recursive: true });
+}
+
 // ─── Cleanup ─────────────────────────────────────────────────────────────────
 session.destroy();
 fs.rmSync(tmpRoot, { recursive: true });


### PR DESCRIPTION
## Problem

If the saved shared-folder path (`smbSharePath` in settings.json) points at a directory that no longer exists, the **whole emulator freezes solid** a few seconds after reaching the desktop — not just the SMB share.

The chain: the guest agent maps `\\HOST\HOST` at every login → guest sends a SYN to port 139 → v86 `tcp-connection` bus event → `wireConn` → `new SmbSession(stalePath)` → `fs.realpathSync()` throws ENOENT. `bus.send` has no exception handling, so the throw unwinds `do_tick()` before it can schedule `next_tick()` — the tick chain dies and the VM freezes (instruction counter stops, CPU not halted).

Reproduced with the probe harness (`WIN95_PROBE=1`, stale path in settings.json): boot → desktop → `Uncaught Error: ENOENT … lstat '…'` on the guest's first SYN → `instructionDelta` drops to 0, `FAIL_HUNG` forever. Since the guest re-maps the share on every login, every boot hits this within seconds.

## What changed

**SMB server (`server.ts`, `smb.ts`)**
- `SmbSession`'s constructor never throws. The share root resolves through a non-throwing `safeRealpathDir()` and may be null.
- The root is re-validated on every TREE_CONNECT and NetShareEnum. While missing: that tree answers `ERRSRV/ERRinvnetname` ("The network name cannot be found"), the share is hidden from enumeration, and `\\HOST\TOOLS` + `IPC$` keep working. If the directory reappears, the share comes back without a restart.

**Backstops (`index.ts`, `nbns.ts`)**
- Everything reachable from v86's tick is wrapped in try/catch: the `tcp-connection` bus handler, the old-API `on_tcp_connection` hook, the per-connection data handler, and the NBNS `net0-send` handler. Failures decline the connection or drop the frame instead of escaping into the emulator.

**Startup re-validation (`emulator.tsx`)**
- The saved path is re-checked when the emulator starts (the existing `SET_SMB_SHARE_PATH` validation can't catch directories deleted after being saved). A stale path boots as "no folder shared" with a console warning; TOOLS is still served.

## Verification

- `test-standalone.ts`: 19 new tests (76 total, all passing) — missing root at construction, null root, root deleted mid-session, root restored mid-session, TOOLS survival, share hiding from NetShareEnum.
- Live probe, stale path in settings at boot: the guest's `NET USE` retries are all refused cleanly; the VM ran ~2 hours at the desktop with zero uncaught exceptions (previously froze in ~10 s).
- Live probe, directory deleted *while the VM is running* (bypasses startup validation, hits the original crash site): tree connects logged `share root unavailable (…)`, the guest retried 4×, the VM stayed healthy (`verdict=SUCCESS`, CPU active).
- `npm run tsc` clean.

## Notes for review

- `wireConn` no longer RSTs port-139 connections when no folder is configured — it serves a session with just `\\HOST\TOOLS`. Previously "no folder" meant no SMB at all; now the tools share is always reachable.
- The SMB README documents the no-throw rule for anything running inside a bus callback, since this class of bug kills the whole VM.