### PR TITLE
Fix stale state-v4.bin references in probe docs and probe-tcp.sh

### DIFF
--- a/.claude/skills/probe-win95/SKILL.md
+++ b/.claude/skills/probe-win95/SKILL.md
@@ -14,6 +14,17 @@ up — three pieces:
 | `src/renderer/smb/index.ts` | Wraps `console.log` so `[smb]` and `[nbns]` lines tee to `$TMPDIR/windows95-smb.log` (outside Electron, readable by any polling script — no CDP needed). |
 | `tools/probe-boot.sh` | One-shot: kill leftovers → parcel build → launch Electron → poll `/tmp/win95-probe.done` → report → kill. |
 
+## Running from a git worktree
+
+`images/` is gitignored, so a fresh worktree has no disk image or default
+state and every probe will fail at boot. Clone them from the main checkout
+first (APFS clonefile — instant, no extra disk space):
+
+```sh
+mkdir -p images
+cp -c "$(git rev-parse --git-common-dir)/.."/images/*.{img,bin} images/
+```
+
 ## One-shot boot test
 
 ```sh
@@ -26,7 +37,7 @@ Prints SUCCESS or a FAIL verdict. ~40s on a clean run.
 
 ```sh
 pkill -9 -f "windows95.*electron"; sleep 2
-rm -f "$HOME/Library/Application Support/windows95/state-v4.bin"
+rm -f "$HOME/Library/Application Support/windows95/"state-v*.bin
 rm -f /tmp/win95-probe.json /tmp/win95-probe.done \
       "$TMPDIR/windows95-smb.log"
 
@@ -76,9 +87,10 @@ Enter.
 
 - **Sporadic bluescreens are normal** on all v86 versions. One FAIL_VXDLINK
   or FAIL_HUNG doesn't prove anything — retry up to 3×.
-- **Always clean state** (`state-v4.bin`) before a probe. `pkill` on a
-  wedged Electron triggers `onbeforeunload`, saving the *corrupted* state.
-  Deleting it forces fallback to `images/default-state.bin`.
+- **Always clean state** (`state-v*.bin` — the suffix tracks `STATE_VERSION`
+  in `src/constants.ts`, so never hardcode a version) before a probe. `pkill`
+  on a wedged Electron triggers `onbeforeunload`, saving the *corrupted*
+  state. Deleting it forces fallback to `images/default-state.bin`.
 - **Don't trust the text buffer in graphics mode.** After desktop (≥640×480)
   the stale BIOS text lingers in the buffer. The harness's `phase` field
   accounts for this; don't re-read `textScreen` in a `desktop` phase and

--- a/tools/probe-tcp.sh
+++ b/tools/probe-tcp.sh
@@ -13,7 +13,7 @@ TIMEOUT=${TIMEOUT:-90}
 
 pkill -9 -f "windows95.*electron" 2>/dev/null || true
 sleep 1
-rm -f "$HOME/Library/Application Support/windows95/state-v4.bin"
+rm -f "$HOME/Library/Application Support/windows95/"state-v*.bin
 rm -f "$STATUS" /tmp/win95-probe.done /tmp/win95-screen.png "$TRACE" "$RELAY"
 
 rm -rf dist


### PR DESCRIPTION
## What this does

The probe-win95 skill doc and `tools/probe-tcp.sh` still reference `state-v4.bin` in their state-cleanup commands. `STATE_VERSION` in `src/constants.ts` is now 5, so the saved state lives at `state-v5.bin` and those `rm` calls silently delete nothing.

This matters for `probe-tcp.sh` in particular: the doc itself notes that skipping state cleanup is the #1 cause of spurious bad probe verdicts, and that script's cleanup has been a no-op since the version bump.

## Changes

- `.claude/skills/probe-win95/SKILL.md` and `tools/probe-tcp.sh`: replace the hardcoded `state-v4.bin` with a `state-v*.bin` glob (kept outside the quoted path so it expands), so cleanup keeps working across future `STATE_VERSION` bumps
- SKILL.md now points readers at `STATE_VERSION` in `src/constants.ts` instead of naming a specific version
- SKILL.md gains a "Running from a git worktree" section: `images/` is gitignored, so a fresh worktree has no disk image or default state and every probe fails at boot. The new section shows how to clone them from the main checkout:
  ```sh
  mkdir -p images
  cp -c "$(git rev-parse --git-common-dir)/.."/images/*.{img,bin} images/
  ```

## Verification

- `grep -rn state-v4` over `.claude/skills`, `tools/`, and `src/` returns nothing
- The new glob expands to the actual `state-v5.bin` path on a machine with saved state
- `git rev-parse --git-common-dir` resolves to the main checkout's `.git` from inside a worktree, so the `cp -c` line copies `windows95.img` and `default-state.bin` (and skips unrelated backup files)