### PR TITLE
Run QEMU with vmport=off so the mouse is usable

### DIFF
--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -46,3 +46,27 @@ qemu-system-i386 \
     -netdev user,id=mynet0 \
     -device ne2k_isa,netdev=mynet0,irq=10
 ```
+
+## Mouse: keep `vmport=off`
+
+The image has VBADOS (`VBMOUSE.EXE` + `VBMOUSE.DRV`) installed for seamless
+host-cursor tracking in the app. Don't enable QEMU's VMware backdoor
+(`-M pc,vmport=on`) expecting the same thing — the cursor becomes unusably
+laggy. The `yarn run qemu` script therefore passes `vmport=off`, which makes
+VBMOUSE fall back to a plain relative PS/2 mouse (click the window to grab,
+Ctrl+Alt+G to release).
+
+Why it breaks with `vmport=on`: QEMU's `vmmouse` queues **every** host
+pointer event (4 words each, up to 256 events) and notifies the guest by
+injecting a fake PS/2 packet per event. VBMOUSE reads exactly **one**
+4-word packet per PS/2 interrupt (`mousetsr.c, handle_ps2_packet` — an
+`if`, not a `while`). Whenever a single notification is dropped (PS/2
+disabled during driver init, PS/2 output queue full, boot), the queue gains
+a permanent backlog: from then on the guest only ever reads stale events
+and the cursor trails minutes behind. v86 doesn't have this problem because
+our `vmware-abspointer` patch coalesces motion packets in place — the guest
+is never more than one move behind by design.
+
+Fixing it for real would mean either teaching QEMU's `hw/i386/vmmouse.c` to
+coalesce motion events, or patching VBADOS to drain the whole queue per
+interrupt and baking the rebuilt driver into the image.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "prettier --write src/**/*.{ts,tsx} && npm run check-links",
     "tsc": "tsc -p tsconfig.json --noEmit",
     "check-links": "node tools/check-links.js",
-    "qemu": "qemu-system-i386 -m 128 -drive file=images/windows95.img,format=raw -device sb16 -M pc,acpi=off,vmport=on -cpu pentium -netdev user,id=mynet0 -device ne2k_isa,netdev=mynet0,iobase=0x300,irq=10",
+    "qemu": "qemu-system-i386 -m 128 -drive file=images/windows95.img,format=raw -device sb16 -M pc,acpi=off,vmport=off -cpu pentium -netdev user,id=mynet0 -device ne2k_isa,netdev=mynet0,iobase=0x300,irq=10",
     "qemu:cdrom": "npm run qemu -- -cdrom",
     "postinstall": "patch-package"
   },


### PR DESCRIPTION
## What this does

Makes `yarn run qemu` usable by switching the QEMU machine flag from `vmport=on` to `vmport=off`, and documents why in `docs/qemu.md`.

## Why

The disk image ships VBADOS (`VBMOUSE.EXE`/`VBMOUSE.DRV`) for seamless host-cursor tracking in the app. Under QEMU with `vmport=on`, that same driver makes the mouse unusably laggy — the cursor barely responds and trails far behind.

Root cause (confirmed by booting the image in QEMU 10.2.2 with tracing enabled and by dumping the vmmouse device state):

- QEMU's `vmmouse` queues **every** host pointer event (4 words each, up to 256 events) and notifies the guest with one fake PS/2 packet per event.
- VBADOS reads exactly **one** 4-word packet per PS/2 interrupt (`mousetsr.c handle_ps2_packet` uses `if`, not `while`).
- The moment a single notification is dropped (PS/2 disabled during driver init, PS/2 queue full, boot window), the queue gains a **permanent backlog**: the guest then only ever reads stale events. A device-state dump showed 13 unread pointer events sitting in the queue while the cursor sat still.

The v86 build used by the app does not have this problem because its VMware backdoor implementation coalesces motion packets in place, so the guest is never more than one move behind.

## What changed

- `package.json`: `qemu` script now passes `-M pc,acpi=off,vmport=off`. VBMOUSE falls back to a plain relative PS/2 mouse — standard QEMU behavior (click to grab, Ctrl+Alt+G to release).
- `docs/qemu.md`: new "Mouse: keep `vmport=off`" section explaining the failure mode, so nobody flips it back expecting seamless tracking.

## How it was verified

Booted the actual image in QEMU 10.2.2 (on a disposable copy):

- With `vmport=on`: pointer moves did not move the guest cursor; QEMU's vmmouse queue accumulated unread events; the screensaver kicked in despite continuous mouse input.
- With `vmport=off`: every injected motion moved the cursor immediately, right-click opened the desktop context menu, and mouse activity dismissed the screensaver.

## Follow-up options (not in this PR)

Restoring the seamless absolute mouse under QEMU would require either patching VBADOS to drain the whole queue per interrupt (and baking the rebuilt driver into the image), or patching QEMU's `hw/i386/vmmouse.c` to coalesce motion events.